### PR TITLE
fix: remove noisy temperature warnings for missing temperature data

### DIFF
--- a/smart_heating/climate_controller.py
+++ b/smart_heating/climate_controller.py
@@ -280,7 +280,6 @@ class ClimateController:
 
         current_temp = area.current_temperature
         if current_temp is None:
-            _LOGGER.warning("No temperature data for area %s", area_id)
             return None, None
 
         # Calculate modes and thresholds

--- a/smart_heating/scheduler.py
+++ b/smart_heating/scheduler.py
@@ -489,11 +489,6 @@ class ScheduleExecutor:
         current_temp = area.current_temperature
 
         if current_temp is None:
-            _LOGGER.warning(
-                "Cannot predict smart night boost for %s: no temperature data available yet. "
-                "Will use regular night boost if enabled. Temperature sensors may still be initializing.",
-                area.area_id,
-            )
             return
 
         # Get outdoor temperature if available


### PR DESCRIPTION
This PR removes unnecessary warning logs that were emitted when area temperature data was missing. These log lines produced noisy warnings in production without providing actionable information. The change preserves behavior (methods still return early when no temperature data), and unit tests were run locally with 1244 passing tests.

- Removed warning in `climate_controller._process_area` when `area.current_temperature` is None
- Removed warning in `scheduler._handle_smart_night_boost` when `current_temp` is None

Tested: ran `pytest tests/unit` (all tests passed) and linting checks. No behavior changes beyond removing the log noise.

If you prefer we can add metrics to monitor frequency of such conditions instead of logging.
