### PR TITLE
fix(diagnostic): reduce cognitive complexity in `async_handle_force_thermostat_update` (S3776)

### DIFF
--- a/smart_heating/ha_services/diagnostic_handlers.py
+++ b/smart_heating/ha_services/diagnostic_handlers.py
@@ -13,6 +13,81 @@ from ..const import ATTR_AREA_ID, ATTR_HVAC_MODE, ATTR_TEMPERATURE
 _LOGGER = logging.getLogger(__name__)
 
 
+async def _turn_on_power_switch_if_present(hass, thermostat_id: str) -> None:
+    """Try to find and turn on a matching power switch for the thermostat.
+
+    This will try a few common switch entity_id patterns and wait briefly for
+    the switch to report 'on'."""
+    if "." in thermostat_id:
+        base = thermostat_id.split(".", 1)[1]
+    else:
+        base = thermostat_id
+
+    power_switch_patterns = [
+        f"switch.{base}_power",
+        f"switch.{base}_switch",
+        f"switch.{base}",
+    ]
+
+    for switch_id in power_switch_patterns:
+        state = hass.states.get(switch_id)
+        if not state:
+            continue
+
+        # Turn the switch on if needed and wait for it to report 'on'.
+        await _turn_on_switch(hass, switch_id)
+        break
+
+
+async def _turn_on_switch(hass, switch_id: str) -> None:
+    """Turn on the given switch and wait for it to report 'on'."""
+    state = hass.states.get(switch_id)
+    if getattr(state, "state", None) == "on":
+        return
+
+    _LOGGER.info("Diagnostic: Turning on power switch %s", switch_id)
+    await hass.services.async_call("switch", "turn_on", {"entity_id": switch_id}, blocking=True)
+
+    for _ in range(12):
+        await asyncio.sleep(0.25)
+        state = hass.states.get(switch_id)
+        if state and getattr(state, "state", None) == "on":
+            _LOGGER.info("Diagnostic: Switch %s is now on", switch_id)
+            return
+
+    _LOGGER.warning("Diagnostic: Switch %s did not become 'on' within timeout", switch_id)
+
+
+async def _ensure_climate_on(hass, thermostat_id: str) -> None:
+    """Ensure the climate entity is turned on (fallback path)."""
+    cstate = hass.states.get(thermostat_id)
+    if cstate and getattr(cstate, "state", None) != "on":
+        _LOGGER.info("Diagnostic: Calling climate.turn_on for %s", thermostat_id)
+        await hass.services.async_call(
+            "climate", "turn_on", {"entity_id": thermostat_id}, blocking=True
+        )
+
+
+async def _set_hvac_mode(hass, thermostat_id: str, hvac_mode: str) -> None:
+    _LOGGER.info("Diagnostic: Setting HVAC mode %s for %s", hvac_mode, thermostat_id)
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": thermostat_id, "hvac_mode": hvac_mode},
+        blocking=True,
+    )
+
+
+async def _set_temperature(hass, thermostat_id: str, target_temp: float) -> None:
+    _LOGGER.info("Diagnostic: Setting temperature %.1f°C for %s", target_temp, thermostat_id)
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {"entity_id": thermostat_id, "temperature": target_temp},
+        blocking=True,
+    )
+
+
 async def async_handle_force_thermostat_update(
     call: ServiceCall, area_manager: AreaManager, coordinator: SmartHeatingCoordinator
 ) -> None:
@@ -52,71 +127,16 @@ async def async_handle_force_thermostat_update(
                 "Diagnostic: Forcing updates for thermostat %s (area=%s)", thermostat_id, area_id
             )
 
-            # Try to find common power switch patterns
-            if "." in thermostat_id:
-                base = thermostat_id.split(".", 1)[1]
-            else:
-                base = thermostat_id
+            # Try to ensure any associated power switch is on, then ensure the
+            # climate entity itself is on and apply requested settings.
+            await _turn_on_power_switch_if_present(hass, thermostat_id)
+            await _ensure_climate_on(hass, thermostat_id)
 
-            power_switch_patterns = [
-                f"switch.{base}_power",
-                f"switch.{base}_switch",
-                f"switch.{base}",
-            ]
-
-            for switch_id in power_switch_patterns:
-                state = hass.states.get(switch_id)
-                if state:
-                    # Turn it on if not on
-                    if getattr(state, "state", None) != "on":
-                        _LOGGER.info("Diagnostic: Turning on power switch %s", switch_id)
-                        await hass.services.async_call(
-                            "switch", "turn_on", {"entity_id": switch_id}, blocking=True
-                        )
-
-                        # Wait for it to report on (timeout after ~3s)
-                        for _ in range(12):
-                            await asyncio.sleep(0.25)
-                            state = hass.states.get(switch_id)
-                            if state and getattr(state, "state", None) == "on":
-                                _LOGGER.info("Diagnostic: Switch %s is now on", switch_id)
-                                break
-                        else:
-                            _LOGGER.warning(
-                                "Diagnostic: Switch %s did not become 'on' within timeout",
-                                switch_id,
-                            )
-                    break
-
-            # Fallback: ensure climate entity is on
-            cstate = hass.states.get(thermostat_id)
-            if cstate and getattr(cstate, "state", None) != "on":
-                _LOGGER.info("Diagnostic: Calling climate.turn_on for %s", thermostat_id)
-                await hass.services.async_call(
-                    "climate", "turn_on", {"entity_id": thermostat_id}, blocking=True
-                )
-
-            # Set hvac mode if requested
             if hvac_mode:
-                _LOGGER.info("Diagnostic: Setting HVAC mode %s for %s", hvac_mode, thermostat_id)
-                await hass.services.async_call(
-                    "climate",
-                    "set_hvac_mode",
-                    {"entity_id": thermostat_id, "hvac_mode": hvac_mode},
-                    blocking=True,
-                )
+                await _set_hvac_mode(hass, thermostat_id, hvac_mode)
 
-            # Set temperature if requested
             if target_temp is not None:
-                _LOGGER.info(
-                    "Diagnostic: Setting temperature %.1f°C for %s", target_temp, thermostat_id
-                )
-                await hass.services.async_call(
-                    "climate",
-                    "set_temperature",
-                    {"entity_id": thermostat_id, "temperature": target_temp},
-                    blocking=True,
-                )
+                await _set_temperature(hass, thermostat_id, target_temp)
 
             _LOGGER.info("Diagnostic: Completed forcing thermostat %s", thermostat_id)
 


### PR DESCRIPTION
### Summary

This PR refactors `async_handle_force_thermostat_update` in `smart_heating/ha_services/diagnostic_handlers.py` by extracting helper functions:

- `_turn_on_power_switch_if_present`
- `_turn_on_switch`
- `_ensure_climate_on`
- `_set_hvac_mode`
- `_set_temperature`

These changes aim to reduce cognitive complexity and address SonarQube finding S3776 (issue AZsnah-zuLr6JSPPpflJ).

### Issues closed
Closes: #54

### Testing notes
- Run unit tests: `bash tests/run_tests.sh` (ensure all tests pass and coverage threshold is met)
- Verify no change in runtime behavior for diagnostic service by running the service on a test Home Assistant instance.

### Follow-ups
- After merge, run SonarQube analysis on the branch to ensure the S3776 finding is closed and no new issues are introduced.
