### PR TITLE
fix(history): use COUNT(*) instead of rowcount for database stats

### DIFF
--- a/smart_heating/history.py
+++ b/smart_heating/history.py
@@ -681,13 +681,14 @@ class HistoryTracker:
             recorder = get_instance(self.hass)
 
             def _get_stats():
+                from sqlalchemy import func
+
                 with recorder.engine.connect() as conn:
-                    # Count total entries
-                    stmt = select(self._db_table.c.id)
-                    total = conn.execute(stmt).rowcount
+                    # Count total entries using COUNT(*) - rowcount doesn't work for SELECT
+                    stmt = select(func.count()).select_from(self._db_table)
+                    total = conn.execute(stmt).scalar() or 0
 
                     # Count by area
-                    from sqlalchemy import func
 
                     stmt = select(
                         self._db_table.c.area_id,


### PR DESCRIPTION
## Summary

- Fix history time range selectors showing only ~5 minutes of data instead of the requested time range (1h, 2h, 4h, 8h, 24h)
- The root cause was `async_get_database_stats()` using `rowcount` on a SELECT result, which returns -1 in SQLAlchemy
- This caused `async_load()` to incorrectly fall back to JSON storage even when database entries existed
- Changed to use `SELECT COUNT(*)` via `func.count()` for proper row counting

## Test plan

- [x] Run `pytest tests/unit/test_history.py` - all 25 tests pass
- [x] Verify in the UI that time range selectors (1h, 2h, 4h, 8h, 24h, custom) now display the correct historical data
- [x] Confirm database storage is correctly detected and used when entries exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)