### PR TITLE
docs: document merged PR #87 and Device Logs notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
 ### Fixed
 - Preserve zones overview viewport when updating an area's temperature; avoid large list loader during small updates to prevent scrolling/jumps. (frontend)
 - Area cards are no longer clickable; area configuration is now accessible from the area card's three-dots menu (ensures a consistent way to reach settings).
+
+### Chore
+- Fix WebSocket client/server integration for device logs: register `smart_heating/subscribe_device_logs` on the backend, ensure frontend WebSocket commands include an `id` automatically, and remove a temporary `console.debug` used during debugging. This enables the Global Settings → Device Logs panel to subscribe and receive live device events. (frontend + backend) — See PR #87
+
+Note: PR #87 was merged into `main` on 2025-12-20; these entries ensure the changelog reflects the merge.

--- a/CHANGELOG.nl.md
+++ b/CHANGELOG.nl.md
@@ -1,2 +1,7 @@
 ### Opgelost
 - Gebiedskaarten zijn niet langer klikbaar; gebiedsconfiguratie is nu toegankelijk via het menu met drie puntjes op de gebiedskaart (zorgt voor een consistente manier om instellingen te bereiken).
+
+### Chore
+- WebSocket client/server-integratie voor apparaatlogboeken is hersteld: de backend registreert nu `smart_heating/subscribe_device_logs`, de frontend voegt automatisch een `id` toe aan WebSocket-commando's en een tijdelijke `console.debug` voor debuggen is verwijderd. Dit maakt het mogelijk dat Global Settings → Device Logs zich abonneert en live apparaatgebeurtenissen ontvangt. (frontend + backend) — Zie PR #87
+
+Opmerking: PR #87 is op 2025-12-20 samengevoegd in `main`; deze vermeldingen zorgen dat de changelog dit reflecteert.

--- a/docs/en/DEVELOPER.md
+++ b/docs/en/DEVELOPER.md
@@ -325,6 +325,15 @@ This feature demonstrates the full stack for adding a new API endpoint.
        return self.json(result)
    ```
 
+---
+
+## Recent Merge Notes
+
+- PR #87 (fix/remove-ws-debug) — merged into `main` on 2025-12-20: fixes WebSocket client/server integration for device logs. Key points:
+  - Backend: registered `smart_heating/subscribe_device_logs` and forwards `DeviceEvent` objects to subscribed clients.
+  - Frontend: ensures outgoing WS commands include an `id` automatically (handled in `useWebSocket.send()`), and removed a temporary debug log used during development.
+  - This enables the Global Settings → Device Logs panel to subscribe and receive live `device_event` messages.
+  - See the changelog and PR #87 for full details.
 2. **Add route** in `post()` or `get()`:
    ```python
    if len(parts) == 2 and parts[1] == "my_endpoint":

--- a/docs/nl/DEVELOPER.md
+++ b/docs/nl/DEVELOPER.md
@@ -1,3 +1,14 @@
+
+---
+
+## Recente merge-opmerkingen
+
+ - PR #87 (fix/remove-ws-debug) — samengevoegd in `main` op 2025-12-20: Herstelt WebSocket client/server-integratie voor apparaatlogboeken. Belangrijkste punten:
+    - Backend: registreert `smart_heating/subscribe_device_logs` en stuurt `DeviceEvent` objecten door naar geabonneerde clients.
+    - Frontend: zorgt dat uitgaande WS-commando's automatisch een `id` bevatten (gehandeld in `useWebSocket.send()`), en verwijdert een tijdelijke debug-log die tijdens ontwikkeling werd gebruikt.
+    - Dit maakt het mogelijk dat het paneel Globale Instellingen → Device Logs zich abonneert en live `device_event` berichten ontvangt.
+    - Zie de changelog en PR #87 voor volledige details.
+
 # Ontwikkelaar Snelle Referentie
 
 Snelle referentie voor het ontwikkelen en uitbreiden van Smart Heating.


### PR DESCRIPTION
Add merged PR note for #87 and developer notes describing the WebSocket/device logs fix (backend registration of smart_heating/subscribe_device_logs and frontend id autofill).