### PR TITLE
fix(api): preserve multiple safety sensors when adding via API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - Preserve zones overview viewport when updating an area's temperature; avoid large list loader during small updates to prevent scrolling/jumps. (frontend)
 - Area cards are no longer clickable; area configuration is now accessible from the area card's three-dots menu (ensures a consistent way to reach settings).
 
+- Safety sensors: preserve multiple configured safety sensors when adding a new sensor via the API (backend). Previously adding a sensor replaced the entire list; now the API adds or updates a single sensor without clearing others. (fix)
+
 ### Chore
 - Fix WebSocket client/server integration for device logs: register `smart_heating/subscribe_device_logs` on the backend, ensure frontend WebSocket commands include an `id` automatically, and remove a temporary `console.debug` used during debugging. This enables the Global Settings → Device Logs panel to subscribe and receive live device events. (frontend + backend) — See PR #87
 

--- a/CHANGELOG.nl.md
+++ b/CHANGELOG.nl.md
@@ -5,3 +5,5 @@
 - WebSocket client/server-integratie voor apparaatlogboeken is hersteld: de backend registreert nu `smart_heating/subscribe_device_logs`, de frontend voegt automatisch een `id` toe aan WebSocket-commando's en een tijdelijke `console.debug` voor debuggen is verwijderd. Dit maakt het mogelijk dat Global Settings → Device Logs zich abonneert en live apparaatgebeurtenissen ontvangt. (frontend + backend) — Zie PR #87
 
 Opmerking: PR #87 is op 2025-12-20 samengevoegd in `main`; deze vermeldingen zorgen dat de changelog dit reflecteert.
+
+- Veiligheidssensoren: het toevoegen van een nieuwe sensor via de API behoudt nu meerdere geconfigureerde veiligheidsensoren. Voorheen verving het toevoegen een sensor de hele lijst; de API voegt nu één sensor toe of werkt deze bij zonder de andere te verwijderen. (fix)

--- a/tests/unit/test_api_handlers_config.py
+++ b/tests/unit/test_api_handlers_config.py
@@ -569,7 +569,9 @@ class TestConfigHandlers:
         assert body["success"] is True
         assert body["sensor_id"] == "binary_sensor.smoke"
 
-        mock_area_manager.clear_safety_sensors.assert_called_once()
+        # New behavior: adding a safety sensor preserves existing sensors,
+        # so `clear_safety_sensors` should NOT be called here.
+        mock_area_manager.clear_safety_sensors.assert_not_called()
         mock_area_manager.add_safety_sensor.assert_called_once_with(
             sensor_id="binary_sensor.smoke",
             attribute="state",


### PR DESCRIPTION
Preserve existing configured safety sensors when adding/updating a single safety sensor via the API. Also accept falsy alert values (only reject when alert_value is null).