### PR TITLE
fix(safety): use relative import for coordinator_helpers to avoid ModuleNotFoundError

### DIFF
--- a/smart_heating/features/safety_monitor.py
+++ b/smart_heating/features/safety_monitor.py
@@ -207,7 +207,7 @@ class SafetyMonitor:
         ]
         if entry_ids:
             coordinator = self.hass.data[DOMAIN][entry_ids[0]]
-            from smart_heating.utils.coordinator_helpers import call_maybe_async
+            from ..utils.coordinator_helpers import call_maybe_async
 
             await call_maybe_async(coordinator.async_request_refresh)
             _LOGGER.info("Coordinator refresh requested after emergency shutdown")


### PR DESCRIPTION
Use relative import in safety monitor to prevent ModuleNotFoundError when running inside Home Assistant. Runs tests locally; fixes failing import observed in logs.\n\nNo behavior changes beyond import fix.