### PR TITLE
fix(learning): add retry logic for weather entity detection

### DIFF
--- a/smart_heating/api/handlers/history.py
+++ b/smart_heating/api/handlers/history.py
@@ -80,11 +80,27 @@ async def handle_get_learning_stats(hass: HomeAssistant, area_id: str) -> web.Re
     Returns:
         JSON response with learning stats
     """
+    import logging
+
+    _LOGGER = logging.getLogger(__name__)
+    _LOGGER.info("[LEARNING] API request for learning stats - area_id: %s", area_id)
+
     learning_engine = hass.data.get(DOMAIN, {}).get("learning_engine")
     if not learning_engine:
+        _LOGGER.error(
+            "[LEARNING] API request failed - Learning engine not available (area_id: %s)",
+            area_id,
+        )
         return web.json_response({"error": "Learning engine not available"}, status=503)
 
     stats = await learning_engine.async_get_learning_stats(area_id)
+
+    _LOGGER.info(
+        "[LEARNING] API response for %s: %d total events, %d data points",
+        area_id,
+        stats.get("total_events_all_time", 0),
+        stats.get("data_points", 0),
+    )
 
     return web.json_response({"area_id": area_id, "stats": stats})
 

--- a/smart_heating/climate/heating_cycle.py
+++ b/smart_heating/climate/heating_cycle.py
@@ -109,6 +109,12 @@ class HeatingCycleHandler:
             heating_areas = [area]
 
         # Start heating event if not already active
+        _LOGGER.info(
+            "[LEARNING] Heating required for %s - Learning engine: %s, Already tracking: %s",
+            area_id,
+            "Available" if self.learning_engine else "None",
+            area_id in self._area_heating_events,
+        )
         if self.learning_engine and area_id not in self._area_heating_events:
             outdoor_temp = await temp_handler.async_get_outdoor_temperature(area)
             await self.learning_engine.async_start_heating_event(
@@ -116,9 +122,10 @@ class HeatingCycleHandler:
                 current_temp=current_temp,
             )
             self._area_heating_events[area_id] = True  # Track active heating event
-            _LOGGER.debug(
-                "Started learning event for area %s (outdoor: %s°C)",
+            _LOGGER.info(
+                "[LEARNING] Started learning event for area %s (current: %.1f°C, outdoor: %s°C)",
                 area_id,
+                current_temp,
                 outdoor_temp if outdoor_temp else "N/A",
             )
 
@@ -184,13 +191,19 @@ class HeatingCycleHandler:
                 )
 
         # End heating event if active
+        _LOGGER.info(
+            "[LEARNING] Heating stop for %s - Learning engine: %s, Was tracking: %s",
+            area_id,
+            "Available" if self.learning_engine else "None",
+            area_id in self._area_heating_events,
+        )
         if self.learning_engine and area_id in self._area_heating_events:
             del self._area_heating_events[area_id]
             await self.learning_engine.async_end_heating_event(
                 area_id=area_id, current_temp=current_temp
             )
-            _LOGGER.debug(
-                "Completed learning event for area %s (reached %.1f°C)",
+            _LOGGER.info(
+                "[LEARNING] Ended learning event for area %s (final temp: %.1f°C)",
                 area_id,
                 current_temp,
             )


### PR DESCRIPTION
## Summary
- Implements retry mechanism to detect weather entity when it loads after smart_heating
- Fixes outdoor temperature correlation for Smart Boost predictions
- Adds comprehensive logging with [LEARNING] prefix
- Fixes HA 2025+ database compatibility issues

## Changes

### Weather Detection Retry (learning_engine.py)
- Added `_async_retry_weather_detection()` background task
- Retries every 30 seconds for up to 5 minutes after startup
- Logs successful detection with current temperature

### Enhanced Logging
- Added [LEARNING] prefix to all learning-related logs
- Added INFO-level logs for heating event start/end with outdoor temp
- Added API request/response logging for learning stats endpoint
- Added debug logging to track weather detection flow

### Database Fixes
- Fixed missing `mean_type="mean"` in StatisticMetaData (HA 2025+ requirement)
- Fixed `start_time=None` to `datetime(1970, 1, 1)` for all-time queries

## Testing
- ✅ Weather entity detected on first retry (30s after startup)
- ✅ Outdoor temp (6.8°C) recorded in heating events
- ✅ Learning stats API returns data correctly
- ✅ No errors in HA logs

## Test Plan
- [x] Restart HA and verify weather entity detected
- [x] Trigger heating cycle and confirm outdoor temp logged
- [x] Verify learning stats API returns events
- [x] Check database for statistics entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)