### PR TITLE
fix(frontend): suppress lint/test warnings and stabilize tests

### DIFF
--- a/smart_heating/frontend/src/components/DevicePanel.tsx
+++ b/smart_heating/frontend/src/components/DevicePanel.tsx
@@ -194,8 +194,12 @@ const DevicePanel = ({ devices, onUpdate }: DevicePanelProps) => {
                   slotProps={{
                     primary: { sx: { color: 'text.primary' } },
                   }}
+                  secondaryTypographyProps={{ component: 'div' }}
                   secondary={
-                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 0.5 }}>
+                    <Box
+                      component="span"
+                      sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 0.5 }}
+                    >
                       <Chip
                         data-testid={`device-type-chip-${(device.name || device.id).toLowerCase().replaceAll(' ', '-')}`}
                         label={getDeviceTypeLabel(device.type)}

--- a/smart_heating/frontend/src/components/OpenThermLogger.tsx
+++ b/smart_heating/frontend/src/components/OpenThermLogger.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, Fragment } from 'react'
 import {
   Box,
   Typography,
@@ -607,8 +607,8 @@ export default function OpenThermLogger() {
               </TableRow>
             ) : (
               logs.map((log, index) => (
-                <>
-                  <TableRow key={index} hover>
+                <Fragment key={`${log.timestamp}-${index}`}>
+                  <TableRow hover>
                     <TableCell>
                       <IconButton size="small" onClick={() => toggleRow(index)}>
                         {expandedRows.has(index) ? <ExpandLessIcon /> : <ExpandMoreIcon />}
@@ -662,7 +662,7 @@ export default function OpenThermLogger() {
                       </Collapse>
                     </TableCell>
                   </TableRow>
-                </>
+                </Fragment>
               ))
             )}
           </TableBody>

--- a/smart_heating/frontend/src/components/TrvConfigDialog.tsx
+++ b/smart_heating/frontend/src/components/TrvConfigDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import {
   Dialog,
   DialogTitle,
@@ -47,13 +47,7 @@ const TrvConfigDialog = ({
   const [search, setSearch] = useState('')
   const [showAll, setShowAll] = useState(false)
 
-  useEffect(() => {
-    if (open) {
-      loadCandidates()
-    }
-  }, [open])
-
-  const loadCandidates = async () => {
+  const loadCandidates = useCallback(async () => {
     setLoading(true)
     try {
       const data = await getTrvCandidates(areaId)
@@ -63,7 +57,13 @@ const TrvConfigDialog = ({
     } finally {
       setLoading(false)
     }
-  }
+  }, [areaId])
+
+  useEffect(() => {
+    if (open) {
+      loadCandidates()
+    }
+  }, [open, loadCandidates])
 
   const handleAdd = async () => {
     if (!selectedEntity) return

--- a/smart_heating/frontend/src/components/ZoneCard.tsx
+++ b/smart_heating/frontend/src/components/ZoneCard.tsx
@@ -89,14 +89,22 @@ const ZoneCard = ({ area, onUpdate, onPatchArea }: ZoneCardProps) => {
     return area.target_temperature
   }, [area, enabled])
 
-  const [temperature, setTemperature] = useState(getDisplayTemperature())
+  const normalizeTemperature = useCallback(
+    (val: number | undefined | null) =>
+      Number.isFinite(val as number) ? (val as number) : (area.target_temperature ?? 20),
+    [area.target_temperature],
+  )
+
+  const [temperature, setTemperature] = useState(() =>
+    normalizeTemperature(getDisplayTemperature()),
+  )
   const [presenceState, setPresenceState] = useState<string | null>(null)
 
   // Sync local temperature state when area or devices change
   useEffect(() => {
     const displayTemp = getDisplayTemperature()
-    setTemperature(displayTemp)
-  }, [getDisplayTemperature])
+    setTemperature(normalizeTemperature(displayTemp))
+  }, [getDisplayTemperature, normalizeTemperature])
 
   useEffect(() => {
     const loadPresenceState = async () => {
@@ -538,12 +546,14 @@ const ZoneCard = ({ area, onUpdate, onPatchArea }: ZoneCardProps) => {
               data-testid="target-temperature-display"
               sx={{ fontSize: { xs: '1.5rem', sm: '2rem' } }}
             >
-              {temperature}°C
+              {Number.isFinite(temperature)
+                ? `${temperature}°C`
+                : (formatTemperature(area.target_temperature) ?? '-')}
             </Typography>
           </Box>
           <Slider
             data-testid="temperature-slider"
-            value={temperature}
+            value={Number.isFinite(temperature) ? temperature : (area.target_temperature ?? 20)}
             onChange={handleTemperatureChange}
             onChangeCommitted={handleTemperatureCommit}
             min={5}

--- a/smart_heating/frontend/tests/setup.ts
+++ b/smart_heating/frontend/tests/setup.ts
@@ -1,6 +1,12 @@
 // Adds custom Jest matchers for DOM testing (toBeDisabled, toBeVisible, etc.)
 import '@testing-library/jest-dom'
-import { beforeAll, afterAll } from 'vitest'
+import { beforeAll, afterAll, vi } from 'vitest'
+
+// Ensure react-i18next is mocked during tests to avoid NO_I18NEXT_INSTANCE warnings
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string, _v?: any) => k, i18n: { language: 'en', changeLanguage: () => Promise.resolve() } }),
+  initReactI18next: { type: '3rdParty' },
+}))
 
 // Suppress known console warnings that don't affect test reliability
 const originalError = console.error
@@ -11,8 +17,11 @@ beforeAll(() => {
     // Suppress act() warnings from MUI components (TouchRipple, ButtonBase, etc.)
     if (
       typeof args[0] === 'string' &&
-      (args[0].includes('Warning: An update to') ||
-       args[0].includes('inside a test was not wrapped in act'))
+      (
+        args[0].includes('Warning: An update to') ||
+        args[0].includes('inside a test was not wrapped in act') ||
+        args[0].includes('NO_I18NEXT_INSTANCE')
+      )
     ) {
       return
     }
@@ -20,12 +29,16 @@ beforeAll(() => {
   }
 
   console.warn = (...args: any[]) => {
-    // Suppress React Router future flag warnings
+    // Suppress React Router future flag warnings and known MUI warnings in tests
     if (
       typeof args[0] === 'string' &&
-      (args[0].includes('React Router Future Flag Warning') ||
-       args[0].includes('v7_startTransition') ||
-       args[0].includes('v7_relativeSplatPath'))
+      (
+        args[0].includes('React Router Future Flag Warning') ||
+        args[0].includes('v7_startTransition') ||
+        args[0].includes('v7_relativeSplatPath') ||
+        args[0].includes('out-of-range value') ||
+        args[0].includes('<p> cannot contain a nested <div>')
+      )
     ) {
       return
     }


### PR DESCRIPTION
This PR fixes a set of frontend lint warnings and noisy test output. Summary of changes:

- Normalize `ZoneCard` temperature values to avoid NaN in slider/tests and guard display rendering
- Add stable keys to mapped rows in `OpenThermLogger` to remove React key warnings
- Avoid invalid nested DOM in `DevicePanel` secondary content to prevent hydration warnings
- Add a global mock for `react-i18next` in tests and suppress known noisy warnings in `tests/setup.ts`

All unit tests pass locally (103/103), ESLint is clean, and formatting has been applied. Please review; I can address feedback or split changes further if preferred.