### PR TITLE
fix: add preset event type to area logger

### DIFF
--- a/smart_heating/area_logger.py
+++ b/smart_heating/area_logger.py
@@ -25,6 +25,7 @@ EVENT_TYPES = [
     "schedule",
     "smart_boost",
     "sensor",
+    "preset",
     "mode",
 ]
 


### PR DESCRIPTION
Add 'preset' to AreaLogger.EVENT_TYPES so preset events are stored in preset.jsonl and avoid spurious warnings.